### PR TITLE
Fixes compatibility with Anki 26.08+

### DIFF
--- a/src/basic2cloze/basic2cloze.py
+++ b/src/basic2cloze/basic2cloze.py
@@ -23,14 +23,12 @@ except:
 
 CLOZE_RE = r"\{\{c\d+::[\s\S]*?\}\}"
 
-
 def contains_cloze(note: Note):
     for fld in note.fields:
         m = re.search(CLOZE_RE, fld)
         if m:
             return True
     return False
-
 
 def main():
     def convert_basic_to_cloze(problem, note: Note):
@@ -178,3 +176,29 @@ def main():
                 _oldReSearch = None
 
         Editor._onCloze = wrap(Editor._onCloze, _onClozeNew, "around")
+
+    # Bypass JS UI disabling the cloze button when on a Basic note (introduced in Anki commit efaaae8)
+    try:
+        from anki.models import ModelManager
+
+        if hasattr(ModelManager, "cloze_fields") and getattr(ModelManager.cloze_fields, "__name__", "") != "_cloze_fields_new":
+            original_cloze_fields = ModelManager.cloze_fields
+
+            def _cloze_fields_new(self, mid):
+                try:
+                    basicNoteTypes = get_basic_note_type_ids()
+                except Exception:
+                    basicNoteTypes = []
+
+                if mid in basicNoteTypes:
+                    m = self.get(mid)
+                    if m and "flds" in m:
+                        # Return all fields as 'cloze fields' to enable buttons/shortcuts in JS
+                        return list(range(len(m["flds"])))
+                    return []
+
+                return original_cloze_fields(self, mid)
+
+            ModelManager.cloze_fields = _cloze_fields_new
+    except Exception:
+        pass


### PR DESCRIPTION
In recent Anki versions (commit efaaae8ce4139ee9fd4b7d547748600b65e9beab), Anki introduced logic in NoteEditor that checks ModelManager.cloze_fields to disable cloze buttons on fields not designated for cloze.

Because Basic notes do not have cloze fields by default, the editor UI disables the cloze shortcut and button when editing Basic note types.

This PR monkey-patches ModelManager.cloze_fields to return all field indices when queried for Basic note type IDs. This informs the Svelte editor that all fields are valid for cloze operations, restoring button and shortcut functionality.

Coded with help from an LLM.