### PR TITLE
Re-enable the cloze button in the editor on Anki >= 25.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,13 @@
 name: tests
 
+# Deliberately no `schedule:` trigger. The contract tests would ideally run on
+# Anki's release schedule rather than ours, but GitHub disables cron in public
+# repositories after 60 days without activity, so it would go quiet during
+# exactly the dormant stretches it was meant to cover. Run the tests by hand
+# when checking a new Anki release: uv run --no-project pytest
 on:
   push:
   pull_request:
-  # The contract tests exist to notice Anki breaking us, which happens on
-  # Anki's release schedule rather than on ours -- so run them without a push.
-  schedule:
-    - cron: "0 6 * * 1"
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+  # The contract tests exist to notice Anki breaking us, which happens on
+  # Anki's release schedule rather than on ours -- so run them without a push.
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install the newest Anki
+        # aqt is only ever read as source text, never imported, so skip its
+        # PyQt6 dependency
+        run: |
+          uv venv
+          uv pip install pytest anki
+          uv pip install --no-deps aqt
+
+      - name: Show which Anki version we are testing against
+        run: uv run --no-project python -c "import anki.buildinfo; print(anki.buildinfo.version)"
+
+      # --no-project because pyproject.toml carries pytest config only; this
+      # repo is an Anki add-on, not an installable package
+      - run: uv run --no-project pytest -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,9 @@ name: tests
 # exactly the dormant stretches it was meant to cover. Run the tests by hand
 # when checking a new Anki release: uv run --no-project pytest
 on:
+  # push is limited to master so a branch with a PR open is not built twice
   push:
+    branches: [master]
   pull_request:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ profile/
 meta.json
 
 __pycache__/
+.pytest_cache/
+.venv/
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Automatically convert cloze-y things to cloze type.
 
 ![Example image](screenshots/basic2cloze.gif)
 
+## Compatibility
+
+This add-on works with Anki's classic editor. It does nothing in the newer
+Svelte editor, which is currently behind the `SVELTE_EDITOR` experimental
+feature flag and off by default: that editor gets its note data straight from
+the backend and does not run the hooks this add-on relies on.
+
 ## Tests
 
 This add-on breaks when Anki changes, so most of the tests check that the Anki

--- a/README.md
+++ b/README.md
@@ -9,3 +9,18 @@ Patreon link of original author:
 Automatically convert cloze-y things to cloze type.
 
 ![Example image](screenshots/basic2cloze.gif)
+
+## Tests
+
+This add-on breaks when Anki changes, so most of the tests check that the Anki
+internals it hooks into still exist, against whatever Anki release is current.
+Worth running when a new Anki comes out:
+
+```sh
+uv venv
+uv pip install pytest anki
+uv pip install --no-deps aqt   # only read as source text, so PyQt6 isn't needed
+uv run --no-project pytest
+```
+
+A failure names the add-on code that depended on whatever Anki removed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+# anki/aqt are deliberately not pinned here: the point of the contract tests is
+# to run against whatever Anki release is current. See .github/workflows/tests.yml.

--- a/src/basic2cloze/basic2cloze.py
+++ b/src/basic2cloze/basic2cloze.py
@@ -35,6 +35,26 @@ def contains_cloze(note: Note):
     return False
 
 
+def cloze_field_flags(note_type):
+    """Which of this note type's fields to present as cloze fields.
+
+    Conversion maps fields positionally, and only some of the Cloze note
+    type's fields are cloze fields -- Back Extra is not -- so a cloze typed
+    into Basic's Back lands somewhere it deletes nothing. Flag the ones that
+    do survive conversion, rather than all of them.
+    """
+    field_count = len(note_type["flds"])
+
+    cloze_note_type_ids = get_cloze_note_type_ids()
+    if not cloze_note_type_ids:
+        # nothing to convert into, so leave every field as it was rather than
+        # disabling the button the rest of this add-on just went and enabled
+        return [True] * field_count
+
+    cloze_ords = set(mw.col.models.cloze_fields(cloze_note_type_ids[0]))
+    return [ord in cloze_ords for ord in range(field_count)]
+
+
 def main():
     def convert_basic_to_cloze(problem, note: Note):
         if not (
@@ -114,20 +134,20 @@ def main():
     # Anki >= 25.9 additionally greys the cloze button out unless the focused
     # field is one of the note type's cloze fields. Basic has none, so the
     # button shown above would never become usable. Anki sets the per-field
-    # flags from the JS that loadNote runs, so widen them there.
-    def enable_cloze_in_all_fields_for_basic(js: str, note: Note, editor) -> str:
+    # flags from the JS that loadNote runs, so set ours there.
+    def flag_cloze_fields_for_basic(js: str, note: Note, editor) -> str:
         try:
             note_type = note.note_type()
             if note_type["id"] not in get_basic_note_type_ids():
                 return js
 
-            all_fields_are_cloze = json.dumps([True] * len(note_type["flds"]))
+            flags = json.dumps(cloze_field_flags(note_type))
             # guarded so that losing the global degrades to Anki's own flags,
             # rather than rejecting the promise this JS runs in and costing us
             # editor_did_load_note and the duplicate display update with it
             return (
                 f"{js} if (typeof setClozeFields === 'function')"
-                f" {{ setClozeFields({all_fields_are_cloze}); }}"
+                f" {{ setClozeFields({flags}); }}"
             )
         except Exception:
             # this hook drops a callback permanently if it raises
@@ -140,7 +160,7 @@ def main():
     if hasattr(ModelManager, "cloze_fields") and hasattr(
         gui_hooks, "editor_will_load_note"
     ):
-        gui_hooks.editor_will_load_note.append(enable_cloze_in_all_fields_for_basic)
+        gui_hooks.editor_will_load_note.append(flag_cloze_fields_for_basic)
 
     # hide cloze warnings
     if ANKI_VERSION_TUPLE >= (2, 1, 45):

--- a/src/basic2cloze/basic2cloze.py
+++ b/src/basic2cloze/basic2cloze.py
@@ -42,21 +42,26 @@ def contains_cloze(note: Note):
 def cloze_field_flags(note_type):
     """Which of this note type's fields to present as cloze fields.
 
+    None when we have nothing to say and Anki's own flags should stand.
+
     Conversion maps fields positionally, and only some of the Cloze note
     type's fields are cloze fields -- Back Extra is not -- so a cloze typed
     into Basic's Back lands somewhere it deletes nothing. Flag the ones that
     do survive conversion, rather than all of them.
-    """
-    field_count = len(note_type["flds"])
 
+    A note destined for "Cloze (Hide all)" may not match, since that target
+    only becomes knowable once the note has content, and the editor asks at
+    load time. The plain Cloze type is the assumption.
+    """
     cloze_note_type = get_cloze_note_type()
     if not cloze_note_type:
-        # nothing to convert into, so leave every field as it was rather than
-        # disabling the button the rest of this add-on just went and enabled
-        return [True] * field_count
+        # Nothing to convert into, so conversion will refuse and Anki will
+        # block the add. Say nothing and let the button stay disabled rather
+        # than invite a cloze that cannot be added.
+        return None
 
     cloze_ords = set(mw.col.models.cloze_fields(cloze_note_type["id"]))
-    return [ord in cloze_ords for ord in range(field_count)]
+    return [ord in cloze_ords for ord in range(len(note_type["flds"]))]
 
 
 def main():
@@ -145,7 +150,11 @@ def main():
             if note_type["id"] not in get_basic_note_type_ids():
                 return js
 
-            flags = json.dumps(cloze_field_flags(note_type))
+            field_flags = cloze_field_flags(note_type)
+            if field_flags is None:
+                return js
+
+            flags = json.dumps(field_flags)
             # guarded so that losing the global degrades to Anki's own flags,
             # rather than rejecting the promise this JS runs in and costing us
             # editor_did_load_note and the duplicate display update with it

--- a/src/basic2cloze/basic2cloze.py
+++ b/src/basic2cloze/basic2cloze.py
@@ -1,5 +1,6 @@
 import json
 import re
+import traceback
 
 from anki.hooks import wrap
 from anki.models import ModelManager
@@ -121,15 +122,24 @@ def main():
                 return js
 
             all_fields_are_cloze = json.dumps([True] * len(note_type["flds"]))
-            # triggerChanges is what makes the editor pick the flags up; Anki
-            # calls it at the end of its own batch, so call it again after ours.
-            return f"{js} setClozeFields({all_fields_are_cloze}); triggerChanges();"
-        except Exception as e:
+            # guarded so that losing the global degrades to Anki's own flags,
+            # rather than rejecting the promise this JS runs in and costing us
+            # editor_did_load_note and the duplicate display update with it
+            return (
+                f"{js} if (typeof setClozeFields === 'function')"
+                f" {{ setClozeFields({all_fields_are_cloze}); }}"
+            )
+        except Exception:
             # this hook drops a callback permanently if it raises
-            print(e)
+            traceback.print_exc()
             return js
 
-    if hasattr(ModelManager, "cloze_fields"):
+    # cloze_fields arrived with the per-field gating, so it stands in for it.
+    # The hook itself long predates that, but check rather than risk an
+    # AttributeError taking the whole add-on down at import.
+    if hasattr(ModelManager, "cloze_fields") and hasattr(
+        gui_hooks, "editor_will_load_note"
+    ):
         gui_hooks.editor_will_load_note.append(enable_cloze_in_all_fields_for_basic)
 
     # hide cloze warnings

--- a/src/basic2cloze/basic2cloze.py
+++ b/src/basic2cloze/basic2cloze.py
@@ -113,6 +113,7 @@ def main():
 
     # adding the cloze buttons also enables the shortcut!
     # in older version the button and the shortcut exist by default
+    # from 25.9 this only makes them visible -- see the per-field flags below
     def maybe_show_cloze_button(editor: Editor):
         if editor.note.note_type()["id"] not in get_basic_note_type_ids():
             return

--- a/src/basic2cloze/basic2cloze.py
+++ b/src/basic2cloze/basic2cloze.py
@@ -60,8 +60,12 @@ def cloze_field_flags(note_type):
         # than invite a cloze that cannot be added.
         return None
 
+    # Has to stay behind that check. cloze_fields on an id the collection no
+    # longer holds panics out of the Rust backend as a BaseException, which
+    # the except around the caller cannot catch, and Anki drops a filter
+    # callback that raises -- so it would take the whole fix down with it.
     cloze_ords = set(mw.col.models.cloze_fields(cloze_note_type["id"]))
-    return [ord in cloze_ords for ord in range(len(note_type["flds"]))]
+    return [index in cloze_ords for index in range(len(note_type["flds"]))]
 
 
 def main():

--- a/src/basic2cloze/basic2cloze.py
+++ b/src/basic2cloze/basic2cloze.py
@@ -11,7 +11,11 @@ from aqt.editor import Editor
 from aqt.utils import tooltip
 
 from .consts import ANKI_VERSION_TUPLE
-from .model_finder import get_basic_note_type_ids, get_cloze_note_type_ids
+from .model_finder import (
+    get_basic_note_type_ids,
+    get_cloze_note_type,
+    get_cloze_note_type_ids,
+)
 from .model_selector import target_model
 
 try:
@@ -45,13 +49,13 @@ def cloze_field_flags(note_type):
     """
     field_count = len(note_type["flds"])
 
-    cloze_note_type_ids = get_cloze_note_type_ids()
-    if not cloze_note_type_ids:
+    cloze_note_type = get_cloze_note_type()
+    if not cloze_note_type:
         # nothing to convert into, so leave every field as it was rather than
         # disabling the button the rest of this add-on just went and enabled
         return [True] * field_count
 
-    cloze_ords = set(mw.col.models.cloze_fields(cloze_note_type_ids[0]))
+    cloze_ords = set(mw.col.models.cloze_fields(cloze_note_type["id"]))
     return [ord in cloze_ords for ord in range(field_count)]
 
 

--- a/src/basic2cloze/basic2cloze.py
+++ b/src/basic2cloze/basic2cloze.py
@@ -1,6 +1,8 @@
+import json
 import re
 
 from anki.hooks import wrap
+from anki.models import ModelManager
 from anki.notes import Note
 from aqt import gui_hooks, mw
 from aqt.addcards import AddCards
@@ -107,6 +109,28 @@ def main():
             )
 
     gui_hooks.editor_did_load_note.append(maybe_show_cloze_button)
+
+    # Anki >= 25.9 additionally greys the cloze button out unless the focused
+    # field is one of the note type's cloze fields. Basic has none, so the
+    # button shown above would never become usable. Anki sets the per-field
+    # flags from the JS that loadNote runs, so widen them there.
+    def enable_cloze_in_all_fields_for_basic(js: str, note: Note, editor) -> str:
+        try:
+            note_type = note.note_type()
+            if note_type["id"] not in get_basic_note_type_ids():
+                return js
+
+            all_fields_are_cloze = json.dumps([True] * len(note_type["flds"]))
+            # triggerChanges is what makes the editor pick the flags up; Anki
+            # calls it at the end of its own batch, so call it again after ours.
+            return f"{js} setClozeFields({all_fields_are_cloze}); triggerChanges();"
+        except Exception as e:
+            # this hook drops a callback permanently if it raises
+            print(e)
+            return js
+
+    if hasattr(ModelManager, "cloze_fields"):
+        gui_hooks.editor_will_load_note.append(enable_cloze_in_all_fields_for_basic)
 
     # hide cloze warnings
     if ANKI_VERSION_TUPLE >= (2, 1, 45):

--- a/src/basic2cloze/model_finder.py
+++ b/src/basic2cloze/model_finder.py
@@ -49,11 +49,14 @@ def get_cloze_note_type_ids():
 
 
 def get_cloze_note_type():
-    """The note type a Basic note converts into, or None if there isn't one.
+    """The plain Cloze note type, or None if the collection has none.
 
-    Single source of the choice: the conversion and the editor's cloze field
+    Single source of that choice: the conversion and the editor's cloze field
     flags describe the same note type only for as long as they both come
     through here rather than each picking from the id list themselves.
+
+    Not every conversion ends here -- a note using the hide-all syntax goes to
+    "Cloze (Hide all)" instead, which target_model picks separately.
     """
     cloze_note_type_ids = get_cloze_note_type_ids()
     if not cloze_note_type_ids:

--- a/src/basic2cloze/model_finder.py
+++ b/src/basic2cloze/model_finder.py
@@ -9,7 +9,10 @@ _cloze_note_type_ids = []
 
 
 def model_ids_for_names(names):
-    return [id for id in [mw.col.models.id_for_name(name) for name in names if name] if id]
+    ids = (mw.col.models.id_for_name(name) for name in names if name)
+    # in an English collection the localised name resolves to the same note
+    # type as the English one, so the same id routinely turns up twice
+    return list(dict.fromkeys(id for id in ids if id))
 
 
 def get_models():
@@ -43,3 +46,17 @@ def get_basic_note_type_ids():
 
 def get_cloze_note_type_ids():
     return _cloze_note_type_ids
+
+
+def get_cloze_note_type():
+    """The note type a Basic note converts into, or None if there isn't one.
+
+    Single source of the choice: the conversion and the editor's cloze field
+    flags describe the same note type only for as long as they both come
+    through here rather than each picking from the id list themselves.
+    """
+    cloze_note_type_ids = get_cloze_note_type_ids()
+    if not cloze_note_type_ids:
+        return None
+
+    return mw.col.models.get(cloze_note_type_ids[0])

--- a/src/basic2cloze/model_selector.py
+++ b/src/basic2cloze/model_selector.py
@@ -1,8 +1,6 @@
 import re
 
-from aqt import mw
-
-from .model_finder import get_basic_note_type_ids, get_cloze_note_type_ids
+from .model_finder import get_basic_note_type_ids, get_cloze_note_type
 
 clozeHideAllType = "Cloze (Hide all)"
 
@@ -19,7 +17,7 @@ def target_model(note):
     # Basic cloze type
     for _, val in note.items():
         if re.search(r"\{\{c(\d+)::", val):
-            return mw.col.models.get(get_cloze_note_type_ids()[0]) if get_cloze_note_type_ids() else None
+            return get_cloze_note_type()
 
     # None for no-change
     return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def load_addon(monkeypatch):
     registers the hooks.
     """
 
-    def load(*, cloze_fields_exists: bool):
+    def load(*, cloze_fields_exists: bool, hook_exists: bool = True):
         profile_hooks = []
 
         anki = types.ModuleType("anki")
@@ -82,9 +82,10 @@ def load_addon(monkeypatch):
             add_cards_will_add_note=FilterHook(),
             add_cards_did_init=FilterHook(),
             editor_did_load_note=FilterHook(),
-            editor_will_load_note=FilterHook(),
             profile_did_open=FilterHook(),
         )
+        if hook_exists:
+            gui_hooks.editor_will_load_note = FilterHook()
 
         aqt = types.ModuleType("aqt")
         aqt.gui_hooks = gui_hooks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,16 +87,21 @@ def load_addon(monkeypatch):
 
         existing_notetypes = set(notetype_ids.values()) - set(deleted_note_type_ids)
 
+        def cloze_fields(notetype_id):
+            if notetype_id not in existing_notetypes:
+                # the real backend panics on an unknown id, and a panic is a
+                # BaseException, so the add-on's except Exception won't save it
+                raise BaseException(f"panic: no note type {notetype_id}")
+            # only the Cloze note type has cloze fields, so asking about the
+            # wrong one has to come back empty rather than quietly succeed
+            return list(cloze_ords) if notetype_id == CLOZE_ID else []
+
         models = types.SimpleNamespace(
             id_for_name=notetype_ids.get,
             get=lambda notetype_id: (
                 {"id": notetype_id} if notetype_id in existing_notetypes else None
             ),
-            # only the Cloze note type has cloze fields, so asking about the
-            # wrong one has to come back empty rather than quietly succeed
-            cloze_fields=lambda notetype_id: (
-                list(cloze_ords) if notetype_id == CLOZE_ID else []
-            ),
+            cloze_fields=cloze_fields,
         )
         mw = types.SimpleNamespace(col=types.SimpleNamespace(models=models))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,14 @@ def load_addon(monkeypatch):
     registers the hooks.
     """
 
-    def load(*, cloze_fields_exists: bool, hook_exists: bool = True):
+    def load(
+        *,
+        cloze_fields_exists: bool,
+        hook_exists: bool = True,
+        has_cloze_note_type: bool = True,
+        # stock Cloze: Text is a cloze field, Back Extra is not
+        cloze_ords: tuple = (0,),
+    ):
         profile_hooks = []
 
         anki = types.ModuleType("anki")
@@ -71,12 +78,15 @@ def load_addon(monkeypatch):
         anki_models = types.ModuleType("anki.models")
         anki_models.ModelManager = ModelManager
 
-        notetype_ids = {"Basic": BASIC_ID, "Cloze": CLOZE_ID}
-        mw = types.SimpleNamespace(
-            col=types.SimpleNamespace(
-                models=types.SimpleNamespace(id_for_name=notetype_ids.get)
-            )
+        notetype_ids = {"Basic": BASIC_ID}
+        if has_cloze_note_type:
+            notetype_ids["Cloze"] = CLOZE_ID
+
+        models = types.SimpleNamespace(
+            id_for_name=notetype_ids.get,
+            cloze_fields=lambda notetype_id: list(cloze_ords),
         )
+        mw = types.SimpleNamespace(col=types.SimpleNamespace(models=models))
 
         gui_hooks = types.SimpleNamespace(
             add_cards_will_add_note=FilterHook(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,13 @@ def load_addon(monkeypatch):
 
         import basic2cloze  # noqa: F401  -- importing registers the hooks
 
+        # Plain del, not monkeypatch: this import has to be forgotten for good,
+        # or a later test gets a basic2cloze still bound to these stubs. The
+        # hooks registered above keep working, they hold the functions directly.
+        for name in list(sys.modules):
+            if name.split(".")[0] == "basic2cloze":
+                del sys.modules[name]
+
         for name, callback in profile_hooks:
             if name == "profileLoaded":
                 callback()  # populates model_finder's cached notetype ids

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,9 @@ def load_addon(monkeypatch):
         has_cloze_note_type: bool = True,
         # stock Cloze: Text is a cloze field, Back Extra is not
         cloze_ords: tuple = (0,),
+        # ids the cache still knows but the collection no longer has, i.e.
+        # note types deleted after profile load
+        deleted_note_type_ids: tuple = (),
     ):
         profile_hooks = []
 
@@ -82,12 +85,18 @@ def load_addon(monkeypatch):
         if has_cloze_note_type:
             notetype_ids["Cloze"] = CLOZE_ID
 
+        existing_notetypes = set(notetype_ids.values()) - set(deleted_note_type_ids)
+
         models = types.SimpleNamespace(
             id_for_name=notetype_ids.get,
             get=lambda notetype_id: (
-                {"id": notetype_id} if notetype_id in notetype_ids.values() else None
+                {"id": notetype_id} if notetype_id in existing_notetypes else None
             ),
-            cloze_fields=lambda notetype_id: list(cloze_ords),
+            # only the Cloze note type has cloze fields, so asking about the
+            # wrong one has to come back empty rather than quietly succeed
+            cloze_fields=lambda notetype_id: (
+                list(cloze_ords) if notetype_id == CLOZE_ID else []
+            ),
         )
         mw = types.SimpleNamespace(col=types.SimpleNamespace(models=models))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,142 @@
+"""Lets the add-on be imported without Anki, by standing in for what it imports.
+
+These stubs only prove our own code does what we meant; they cannot notice Anki
+changing underneath us. test_anki_api_contract.py is what covers that.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+
+BASIC_ID = 1111
+CLOZE_ID = 2222
+
+
+class FilterHook:
+    """Stands in for an Anki hook, keeping the callbacks so tests can call them."""
+
+    def __init__(self):
+        self.callbacks = []
+
+    def append(self, callback):
+        self.callbacks.append(callback)
+
+
+class FakeNote:
+    def __init__(self, notetype_id, field_count):
+        self.notetype_id = notetype_id
+        self.field_count = field_count
+
+    def note_type(self):
+        return {
+            "id": self.notetype_id,
+            "flds": [{"name": f"field{i}"} for i in range(self.field_count)],
+        }
+
+
+@pytest.fixture
+def load_addon(monkeypatch):
+    """Import the add-on against stubbed Anki modules and return its gui_hooks.
+
+    `basic2cloze.__init__` calls main() on import, so importing is what
+    registers the hooks.
+    """
+
+    def load(*, cloze_fields_exists: bool):
+        profile_hooks = []
+
+        anki = types.ModuleType("anki")
+        anki.version = "26.8.1"
+
+        anki_hooks = types.ModuleType("anki.hooks")
+        anki_hooks.wrap = lambda old, new, position: old
+        anki_hooks.addHook = lambda name, cb: profile_hooks.append((name, cb))
+
+        anki_notes = types.ModuleType("anki.notes")
+        anki_notes.Note = FakeNote
+        anki_notes.NoteFieldsCheckResult = types.SimpleNamespace(
+            NORMAL=0, NOTETYPE_NOT_CLOZE=1, FIELD_NOT_CLOZE=2
+        )
+
+        class ModelManager:
+            pass
+
+        if cloze_fields_exists:
+            ModelManager.cloze_fields = lambda self, mid: []
+
+        anki_models = types.ModuleType("anki.models")
+        anki_models.ModelManager = ModelManager
+
+        notetype_ids = {"Basic": BASIC_ID, "Cloze": CLOZE_ID}
+        mw = types.SimpleNamespace(
+            col=types.SimpleNamespace(
+                models=types.SimpleNamespace(id_for_name=notetype_ids.get)
+            )
+        )
+
+        gui_hooks = types.SimpleNamespace(
+            add_cards_will_add_note=FilterHook(),
+            add_cards_did_init=FilterHook(),
+            editor_did_load_note=FilterHook(),
+            editor_will_load_note=FilterHook(),
+            profile_did_open=FilterHook(),
+        )
+
+        aqt = types.ModuleType("aqt")
+        aqt.gui_hooks = gui_hooks
+        aqt.mw = mw
+
+        aqt_addcards = types.ModuleType("aqt.addcards")
+        aqt_addcards.AddCards = type("AddCards", (), {})
+
+        aqt_editor = types.ModuleType("aqt.editor")
+        aqt_editor.Editor = type(
+            "Editor",
+            (),
+            {
+                "_update_duplicate_display": lambda self, result: None,
+                "_onCloze": lambda self: None,
+            },
+        )
+        aqt_editor.MODEL_CLOZE = 1
+
+        aqt_utils = types.ModuleType("aqt.utils")
+        aqt_utils.tooltip = lambda *args, **kwargs: None
+        aqt_utils.tr = types.SimpleNamespace(
+            notetypes_basic_name=lambda: "Basic",
+            notetypes_cloze_name=lambda: "Cloze",
+        )
+
+        stubs = {
+            "anki": anki,
+            "anki.hooks": anki_hooks,
+            "anki.notes": anki_notes,
+            "anki.models": anki_models,
+            "aqt": aqt,
+            "aqt.addcards": aqt_addcards,
+            "aqt.editor": aqt_editor,
+            "aqt.utils": aqt_utils,
+        }
+
+        # monkeypatch restores sys.modules afterwards, so the real anki stays
+        # importable for the contract tests however these run interleaved
+        for name in list(sys.modules):
+            if name.split(".")[0] in ("anki", "aqt", "basic2cloze"):
+                monkeypatch.delitem(sys.modules, name)
+        for name, module in stubs.items():
+            monkeypatch.setitem(sys.modules, name, module)
+        monkeypatch.syspath_prepend(str(SRC))
+
+        import basic2cloze  # noqa: F401  -- importing registers the hooks
+
+        for name, callback in profile_hooks:
+            if name == "profileLoaded":
+                callback()  # populates model_finder's cached notetype ids
+
+        return gui_hooks
+
+    return load

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,9 @@ def load_addon(monkeypatch):
 
         models = types.SimpleNamespace(
             id_for_name=notetype_ids.get,
+            get=lambda notetype_id: (
+                {"id": notetype_id} if notetype_id in notetype_ids.values() else None
+            ),
             cloze_fields=lambda notetype_id: list(cloze_ords),
         )
         mw = types.SimpleNamespace(col=types.SimpleNamespace(models=models))

--- a/tests/test_anki_api_contract.py
+++ b/tests/test_anki_api_contract.py
@@ -74,8 +74,8 @@ def test_load_note_filters_its_js_through_the_hook():
     name, editor = source_of("aqt", *EDITOR_MODULES)
 
     assert "gui_hooks.editor_will_load_note(" in editor, (
-        f"{name} no longer filters its load JS -- the cloze-field widening in "
-        "enable_cloze_in_all_fields_for_basic will silently stop applying"
+        f"{name} no longer filters its load JS -- the flags set by "
+        "flag_cloze_fields_for_basic will silently stop applying"
     )
 
 
@@ -93,14 +93,29 @@ def test_cloze_fields_are_set_in_the_js_batch_we_filter():
 
 def editor_bundle() -> str:
     bundle = package_dir("_aqt") / "data" / "web" / "js" / "editor.js"
-    if not bundle.exists():
-        pytest.skip("editor.js bundle not present in this build")
+    # not skipped: losing this bundle would mean the classic editor is gone,
+    # which is exactly the change worth being told about
+    assert bundle.exists(), f"{bundle.name} is no longer shipped"
     return bundle.read_text(encoding="utf8", errors="replace")
 
 
 def test_editor_frontend_exposes_set_cloze_fields():
-    """enable_cloze_in_all_fields_for_basic calls this global by name."""
-    assert "setClozeFields" in editor_bundle()
+    """flag_cloze_fields_for_basic calls this global by name."""
+    bundle = editor_bundle()
+
+    # the name alone also appears on internal references, so look for it as a
+    # key of the object the editor assigns onto globalThis -- that assignment
+    # is what makes our appended JS able to call it at all
+    # the bundle makes several such assignments, so check them all
+    assignments = bundle.split("Object.assign(globalThis,")[1:]
+    assert assignments, (
+        "the editor bundle no longer assigns anything onto globalThis; how it "
+        "exposes setClozeFields now needs re-checking"
+    )
+    assert any("setClozeFields:" in body[:3000] for body in assignments), (
+        "setClozeFields is no longer among the editor's globals, so the JS "
+        "appended by flag_cloze_fields_for_basic can no longer call it"
+    )
 
 
 def test_editor_frontend_exposes_the_notetype_toolbar():

--- a/tests/test_anki_api_contract.py
+++ b/tests/test_anki_api_contract.py
@@ -1,0 +1,128 @@
+"""Checks that the Anki internals this add-on hooks into still exist.
+
+Every bug in this add-on's history has been "Anki changed", not "our logic is
+wrong", so these tests are pointed at Anki rather than at us. Run them against
+the newest Anki release to find out what the next release broke.
+
+`aqt` is inspected as source text rather than imported, so this needs no Qt:
+install it with `--no-deps` and nothing here imports it.
+"""
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# anki.hooks_gen imports anki.cards, so importing anki.models or anki.notes
+# first hits a circular import; anki.collection pulls them in in a working order
+pytest.importorskip("anki.collection")
+
+from anki.models import ModelManager  # noqa: E402
+from anki.notes import NoteFieldsCheckResult  # noqa: E402
+
+
+def package_dir(name: str) -> Path:
+    spec = importlib.util.find_spec(name)
+    if spec is None or not spec.submodule_search_locations:
+        pytest.skip(f"{name} is not installed")
+    return Path(list(spec.submodule_search_locations)[0])
+
+
+def source_of(package: str, *candidates: str) -> tuple[str, str]:
+    """Return (filename, text) of the first candidate that exists.
+
+    Anki moves code between modules (Editor lived in aqt/editor.py until 26.8
+    moved it to aqt/editor_legacy.py), so callers pass every known home.
+    """
+    directory = package_dir(package)
+    for candidate in candidates:
+        path = directory / candidate
+        if path.exists():
+            return candidate, path.read_text(encoding="utf8", errors="replace")
+    pytest.fail(f"none of {candidates} found in {package} -- did Anki move them?")
+
+
+EDITOR_MODULES = ("editor_legacy.py", "editor.py")
+ADDCARDS_MODULES = ("addcards_legacy.py", "addcards.py")
+
+
+def test_cloze_fields_exists_on_model_manager():
+    """main() gates the cloze-field widening on this attribute existing."""
+    assert hasattr(ModelManager, "cloze_fields")
+
+
+def test_editor_will_load_note_hook_exists():
+    """We append our setClozeFields() call through this filter hook."""
+    _, hooks = source_of("_aqt", "hooks.py")
+
+    assert "editor_will_load_note = " in hooks
+
+
+def function_containing(source: str, needle: str) -> str:
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        body = ast.get_source_segment(source, node) or ""
+        if needle in body:
+            return body
+    return ""
+
+
+def test_load_note_filters_its_js_through_the_hook():
+    """Our appended JS only runs because loadNote filters the batch first."""
+    name, editor = source_of("aqt", *EDITOR_MODULES)
+
+    assert "gui_hooks.editor_will_load_note(" in editor, (
+        f"{name} no longer filters its load JS -- the cloze-field widening in "
+        "enable_cloze_in_all_fields_for_basic will silently stop applying"
+    )
+
+
+def test_cloze_fields_are_set_in_the_js_batch_we_filter():
+    """Our override has to land in the same batch, not a separate eval."""
+    name, editor = source_of("aqt", *EDITOR_MODULES)
+
+    load_note = function_containing(editor, "gui_hooks.editor_will_load_note(")
+    assert load_note, f"{name} no longer filters any JS through the hook"
+    assert "setClozeFields(" in load_note, (
+        f"setClozeFields moved out of the {name} function that filters its JS "
+        "through editor_will_load_note, so appending to that JS no longer wins"
+    )
+
+
+@pytest.mark.parametrize("global_name", ["setClozeFields", "triggerChanges"])
+def test_editor_frontend_exposes_the_globals_we_call(global_name):
+    """Our JS calls these two by name in the editor webview."""
+    bundle = package_dir("_aqt") / "data" / "web" / "js" / "editor.js"
+    if not bundle.exists():
+        pytest.skip("editor.js bundle not present in this build")
+
+    assert global_name in bundle.read_text(encoding="utf8", errors="replace")
+
+
+def test_add_note_problem_is_filtered_through_addons():
+    """convert_basic_to_cloze clears Anki's objection through this filter."""
+    name, addcards = source_of("aqt", *ADDCARDS_MODULES)
+
+    assert "gui_hooks.add_cards_will_add_note(" in addcards, (
+        f"{name} no longer filters the add problem through add-ons -- Basic "
+        "notes containing clozes would be rejected before we convert them"
+    )
+
+
+@pytest.mark.parametrize(
+    "member", ["NORMAL", "NOTETYPE_NOT_CLOZE", "FIELD_NOT_CLOZE"]
+)
+def test_note_fields_check_results_we_suppress(member):
+    """_update_duplicate_display_ignore_cloze_problems_for_basic_notes maps these."""
+    assert hasattr(NoteFieldsCheckResult, member)
+
+
+def test_editor_has_update_duplicate_display():
+    """We wrap this method to hide cloze warnings on Basic notes."""
+    name, editor = source_of("aqt", *EDITOR_MODULES)
+
+    assert "def _update_duplicate_display(" in editor, (
+        f"{name} no longer defines _update_duplicate_display"
+    )

--- a/tests/test_anki_api_contract.py
+++ b/tests/test_anki_api_contract.py
@@ -69,22 +69,15 @@ def function_containing(source: str, needle: str) -> str:
     return ""
 
 
-def test_load_note_filters_its_js_through_the_hook():
-    """Our appended JS only runs because loadNote filters the batch first."""
-    name, editor = source_of("aqt", *EDITOR_MODULES)
-
-    assert "gui_hooks.editor_will_load_note(" in editor, (
-        f"{name} no longer filters its load JS -- the flags set by "
-        "flag_cloze_fields_for_basic will silently stop applying"
-    )
-
-
 def test_cloze_fields_are_set_in_the_js_batch_we_filter():
     """Our override has to land in the same batch, not a separate eval."""
     name, editor = source_of("aqt", *EDITOR_MODULES)
 
     load_note = function_containing(editor, "gui_hooks.editor_will_load_note(")
-    assert load_note, f"{name} no longer filters any JS through the hook"
+    assert load_note, (
+        f"{name} no longer filters its load JS through editor_will_load_note "
+        "-- the flags set by flag_cloze_fields_for_basic will stop applying"
+    )
     assert "setClozeFields(" in load_note, (
         f"setClozeFields moved out of the {name} function that filters its JS "
         "through editor_will_load_note, so appending to that JS no longer wins"

--- a/tests/test_anki_api_contract.py
+++ b/tests/test_anki_api_contract.py
@@ -91,14 +91,36 @@ def test_cloze_fields_are_set_in_the_js_batch_we_filter():
     )
 
 
-@pytest.mark.parametrize("global_name", ["setClozeFields", "triggerChanges"])
-def test_editor_frontend_exposes_the_globals_we_call(global_name):
-    """Our JS calls these two by name in the editor webview."""
+def editor_bundle() -> str:
     bundle = package_dir("_aqt") / "data" / "web" / "js" / "editor.js"
     if not bundle.exists():
         pytest.skip("editor.js bundle not present in this build")
+    return bundle.read_text(encoding="utf8", errors="replace")
 
-    assert global_name in bundle.read_text(encoding="utf8", errors="replace")
+
+def test_editor_frontend_exposes_set_cloze_fields():
+    """enable_cloze_in_all_fields_for_basic calls this global by name."""
+    assert "setClozeFields" in editor_bundle()
+
+
+def test_editor_frontend_exposes_the_notetype_toolbar():
+    """maybe_show_cloze_button reaches the cloze button through this module.
+
+    Widening the cloze fields only enables the button; this is what makes it
+    visible in the first place, so both halves need the frontend to hold still.
+    """
+    bundle = editor_bundle()
+
+    assert '"anki/NoteEditor"' in bundle, (
+        "the editor no longer registers anki/NoteEditor -- the require() in "
+        "maybe_show_cloze_button will stop finding it"
+    )
+    # matched loosely: everything else in that registration is a minified name
+    registration = bundle.split('"anki/NoteEditor"', 1)[1][:200]
+    assert "instances" in registration, (
+        "anki/NoteEditor no longer exposes instances, which "
+        "maybe_show_cloze_button indexes to reach the toolbar"
+    )
 
 
 def test_add_note_problem_is_filtered_through_addons():

--- a/tests/test_cloze_field_hook.py
+++ b/tests/test_cloze_field_hook.py
@@ -84,13 +84,6 @@ def test_a_raising_note_does_not_take_the_hook_down_with_it(widen_cloze_fields):
     assert widen_cloze_fields("js;", ExplodingNote(), None) == "js;"
 
 
-def test_the_appended_js_degrades_if_the_global_disappears(widen_cloze_fields):
-    """A bare call would reject the promise Anki runs this JS in."""
-    js = widen_cloze_fields("js;", FakeNote(BASIC_ID, 1), None)
-
-    assert "typeof setClozeFields === 'function'" in js
-
-
 def test_hook_is_not_registered_on_anki_without_cloze_fields(load_addon):
     """Before Anki 25.9 there were no per-field cloze flags to widen."""
     gui_hooks = load_addon(cloze_fields_exists=False)

--- a/tests/test_cloze_field_hook.py
+++ b/tests/test_cloze_field_hook.py
@@ -42,13 +42,19 @@ def test_flags_follow_a_customised_cloze_note_type(flag_cloze_fields):
     assert "setClozeFields([true, true]);" in js
 
 
-def test_every_field_is_flagged_without_a_cloze_note_type(flag_cloze_fields):
-    """Nothing to convert into, so don't disable what the add-on just enabled."""
+def test_nothing_is_flagged_without_a_cloze_note_type(flag_cloze_fields):
+    """Conversion would refuse and Anki would block the add, so an enabled
+    cloze button could only lead to a note that cannot be added."""
     hook = flag_cloze_fields(has_cloze_note_type=False)
 
-    js = hook("js;", FakeNote(BASIC_ID, 2), None)
+    assert hook("js;", FakeNote(BASIC_ID, 2), None) == "js;"
 
-    assert "setClozeFields([true, true]);" in js
+
+def test_nothing_is_flagged_if_the_cloze_note_type_was_deleted(flag_cloze_fields):
+    """The ids are cached at profile load, so they outlive the note type."""
+    hook = flag_cloze_fields(deleted_note_type_ids=(CLOZE_ID,))
+
+    assert hook("js;", FakeNote(BASIC_ID, 2), None) == "js;"
 
 
 def test_flag_count_follows_the_field_count(widen_cloze_fields):

--- a/tests/test_cloze_field_hook.py
+++ b/tests/test_cloze_field_hook.py
@@ -1,0 +1,53 @@
+"""Covers the JS that enable_cloze_in_all_fields_for_basic appends."""
+
+import pytest
+
+from conftest import BASIC_ID, CLOZE_ID, FakeNote
+
+UNRELATED_ID = 3333
+
+
+@pytest.fixture
+def widen_cloze_fields(load_addon):
+    hook = load_addon(cloze_fields_exists=True).editor_will_load_note
+    assert len(hook.callbacks) == 1
+    return hook.callbacks[0]
+
+
+def test_basic_note_gets_every_field_flagged(widen_cloze_fields):
+    js = widen_cloze_fields("setFields(x);", FakeNote(BASIC_ID, 2), None)
+
+    assert js == "setFields(x); setClozeFields([true, true]); triggerChanges();"
+
+
+def test_flag_count_follows_the_field_count(widen_cloze_fields):
+    js = widen_cloze_fields("js;", FakeNote(BASIC_ID, 5), None)
+
+    assert "setClozeFields([true, true, true, true, true]);" in js
+
+
+def test_cloze_note_is_left_alone(widen_cloze_fields):
+    """Anki already flags these correctly."""
+    assert widen_cloze_fields("js;", FakeNote(CLOZE_ID, 2), None) == "js;"
+
+
+def test_unrelated_note_type_is_left_alone(widen_cloze_fields):
+    assert widen_cloze_fields("js;", FakeNote(UNRELATED_ID, 2), None) == "js;"
+
+
+def test_a_raising_note_does_not_take_the_hook_down_with_it(widen_cloze_fields):
+    """Anki unregisters a filter callback permanently if it raises, so ours
+    has to swallow and pass the JS through untouched."""
+
+    class ExplodingNote:
+        def note_type(self):
+            raise RuntimeError("notetype went away")
+
+    assert widen_cloze_fields("js;", ExplodingNote(), None) == "js;"
+
+
+def test_hook_is_not_registered_on_anki_without_cloze_fields(load_addon):
+    """Before Anki 25.9 there were no per-field cloze flags to widen."""
+    gui_hooks = load_addon(cloze_fields_exists=False)
+
+    assert gui_hooks.editor_will_load_note.callbacks == []

--- a/tests/test_cloze_field_hook.py
+++ b/tests/test_cloze_field_hook.py
@@ -1,4 +1,4 @@
-"""Covers the JS that enable_cloze_in_all_fields_for_basic appends."""
+"""Covers the JS that flag_cloze_fields_for_basic appends."""
 
 import pytest
 
@@ -8,25 +8,54 @@ UNRELATED_ID = 3333
 
 
 @pytest.fixture
-def widen_cloze_fields(load_addon):
-    hook = load_addon(cloze_fields_exists=True).editor_will_load_note
-    assert len(hook.callbacks) == 1
-    return hook.callbacks[0]
+def flag_cloze_fields(load_addon):
+    def make(**kwargs):
+        hook = load_addon(cloze_fields_exists=True, **kwargs).editor_will_load_note
+        assert len(hook.callbacks) == 1
+        return hook.callbacks[0]
+
+    return make
 
 
-def test_basic_note_gets_every_field_flagged(widen_cloze_fields):
+@pytest.fixture
+def widen_cloze_fields(flag_cloze_fields):
+    return flag_cloze_fields()
+
+
+def test_only_fields_that_survive_conversion_are_flagged(widen_cloze_fields):
+    """Basic's Back maps onto Cloze's Back Extra, which is not a cloze field,
+    so offering the button there would invite a cloze that deletes nothing."""
     js = widen_cloze_fields("setFields(x);", FakeNote(BASIC_ID, 2), None)
 
     assert js == (
         "setFields(x); if (typeof setClozeFields === 'function')"
-        " { setClozeFields([true, true]); }"
+        " { setClozeFields([true, false]); }"
     )
 
 
+def test_flags_follow_a_customised_cloze_note_type(flag_cloze_fields):
+    """If the user made Back Extra a cloze field too, Back should follow."""
+    hook = flag_cloze_fields(cloze_ords=(0, 1))
+
+    js = hook("js;", FakeNote(BASIC_ID, 2), None)
+
+    assert "setClozeFields([true, true]);" in js
+
+
+def test_every_field_is_flagged_without_a_cloze_note_type(flag_cloze_fields):
+    """Nothing to convert into, so don't disable what the add-on just enabled."""
+    hook = flag_cloze_fields(has_cloze_note_type=False)
+
+    js = hook("js;", FakeNote(BASIC_ID, 2), None)
+
+    assert "setClozeFields([true, true]);" in js
+
+
 def test_flag_count_follows_the_field_count(widen_cloze_fields):
+    """One flag per field, whatever the Basic note type has been edited into."""
     js = widen_cloze_fields("js;", FakeNote(BASIC_ID, 5), None)
 
-    assert "setClozeFields([true, true, true, true, true]);" in js
+    assert "setClozeFields([true, false, false, false, false]);" in js
 
 
 def test_cloze_note_is_left_alone(widen_cloze_fields):

--- a/tests/test_cloze_field_hook.py
+++ b/tests/test_cloze_field_hook.py
@@ -17,7 +17,10 @@ def widen_cloze_fields(load_addon):
 def test_basic_note_gets_every_field_flagged(widen_cloze_fields):
     js = widen_cloze_fields("setFields(x);", FakeNote(BASIC_ID, 2), None)
 
-    assert js == "setFields(x); setClozeFields([true, true]); triggerChanges();"
+    assert js == (
+        "setFields(x); if (typeof setClozeFields === 'function')"
+        " { setClozeFields([true, true]); }"
+    )
 
 
 def test_flag_count_follows_the_field_count(widen_cloze_fields):
@@ -46,8 +49,24 @@ def test_a_raising_note_does_not_take_the_hook_down_with_it(widen_cloze_fields):
     assert widen_cloze_fields("js;", ExplodingNote(), None) == "js;"
 
 
+def test_the_appended_js_degrades_if_the_global_disappears(widen_cloze_fields):
+    """A bare call would reject the promise Anki runs this JS in."""
+    js = widen_cloze_fields("js;", FakeNote(BASIC_ID, 1), None)
+
+    assert "typeof setClozeFields === 'function'" in js
+
+
 def test_hook_is_not_registered_on_anki_without_cloze_fields(load_addon):
     """Before Anki 25.9 there were no per-field cloze flags to widen."""
     gui_hooks = load_addon(cloze_fields_exists=False)
 
     assert gui_hooks.editor_will_load_note.callbacks == []
+
+
+def test_addon_still_loads_if_anki_drops_the_hook(load_addon):
+    """Registering blind would AttributeError and take the add-on with it."""
+    gui_hooks = load_addon(cloze_fields_exists=True, hook_exists=False)
+
+    assert not hasattr(gui_hooks, "editor_will_load_note")
+    # the rest of the add-on still came up
+    assert gui_hooks.add_cards_will_add_note.callbacks


### PR DESCRIPTION
Alternative to #10, which fixes the same bug by monkey-patching `ModelManager.cloze_fields` globally.

## The bug

Anki 25.9 changed the editor's cloze button from a per-note-type check to a **per-field** one:

1. `editor.loadNote()` calls `col.models.cloze_fields(note.mid)`
2. it converts the ordinals to a per-field bool list and pushes it to the frontend as `setClozeFields([...])`
3. `ClozeButtons.svelte` computes `enabled = alwaysEnabled || ($focusedInput && editingInputIsRichText($focusedInput) && $focusedInput.isClozeField)`

Basic has no cloze fields, so step 1 returns `[]`, every field gets `isClozeField = false`, and the button this add-on shows for Basic notes is **visible but permanently greyed out**, with an inert Ctrl+Shift+C.

This landed in the 25.9 line, not 26.08 — `aqt/editor.py:567` in 25.9.5 already calls `cloze_fields`.

## The fix

Anki already exposes the right seam: `gui_hooks.editor_will_load_note(js, note, editor)` is a filter over the exact JS batch that carries `setClozeFields(...)`, called at `editor_legacy.py:681`. So the add-on appends its own flags for Basic notes only.

Versus patching `ModelManager.cloze_fields`:

- **Scoped to the note being loaded** rather than lying about the Basic note type process-wide. Any other add-on asking `col.models.cloze_fields(basic_mid)` still gets the truth.
- **Officially supported**, so it doesn't depend on `cloze_fields` keeping exactly one caller. (It has exactly one today — `editor_legacy.py:615` — which is why #10 works, but it's safe by coincidence.)
- No re-entrancy guard or global mutation to reason about.

Three details worth knowing:

**Only the fields that survive conversion are flagged.** Conversion maps fields positionally onto the Cloze note type, and only some of its fields are cloze fields — stock Cloze flags ord 0 (`Text`) but not `Back Extra`. So Basic's `Back` is *not* flagged: a cloze typed there lands in `Back Extra`, where Anki still generates a card but nothing is hidden. The ordinals are read from the target rather than hardcoded, so a collection whose Cloze note type was edited to make `Back Extra` a cloze field gets `Back` flagged too.

**Nothing is appended when there is no Cloze note type**, since conversion would refuse and Anki would block the add — an enabled button could only lead to a note that can't be added.

**The injected call is guarded** with `typeof setClozeFields === 'function'`. Our statement runs inside the promise Anki evaluates the load JS in, so a bare call to a vanished global would reject it and take `editor_did_load_note` and the duplicate-display update down with it.

`get_cloze_note_type()` centralises the target choice, so the conversion and the editor flags can't drift apart into describing different note types.

The `hasattr(ModelManager, "cloze_fields")` gate is feature detection for this exact Anki change: the method and `setClozeFields` were introduced together — both absent in 25.2.7, both present in 25.9.5 — so on older versions the hook is never registered and nothing changes.

## Tests

Most of the suite points at Anki rather than at us, because every bug in this add-on's history has been "Anki changed", not "our logic is wrong" — a suite that stubs Anki out would not have caught this one. `tests/test_anki_api_contract.py` asserts against a real installed Anki that each seam still exists: that `loadNote` still filters its JS through `editor_will_load_note` and still emits `setClozeFields` from that same function, that the editor still exposes `setClozeFields` as a global and still registers `anki/NoteEditor`, and that the `NoteFieldsCheckResult` members and `Editor` methods this add-on wraps are still there. `aqt` is read as source text rather than imported, so no Qt is needed.

`tests/test_cloze_field_hook.py` is the narrower kind, driving the registered callback against stubs.

CI installs the newest Anki release and runs both. There is deliberately no cron: GitHub disables scheduled workflows after 60 days of repository inactivity, so it would go quiet during exactly the dormant stretches it was meant to cover. Run them by hand when a new Anki lands — see the README.

## Verified

Checked against the real `anki`/`aqt` 25.2.7, 25.9.5 and 26.8.1 wheels, plus Anki's `NoteEditor.svelte` at the 26.08.1 tag.

**In a running Anki 26.08.1**, driven through a throwaway add-on against a real profile — Add window, note type forced to Basic, each field focused in turn, then the editor DOM read through its shadow roots:

```json
"will_load_note_hook": { "count": 1, "names": ["flag_cloze_fields_for_basic"] },
"hook_0": { "changed": true, "tail": "... if (typeof setClozeFields === 'function') { setClozeFields([true, false]); }" },
"setup":   { "notetype": "Basic", "cloze_ords": [0] },
"field_0": { "focused_tag": "ANKI-EDITABLE", "contenteditable": true, "cloze_disabled": [false] },
"field_1": { "focused_tag": "ANKI-EDITABLE", "contenteditable": true, "cloze_disabled": [true] }
```

Enabled on `Front`, disabled on `Back`, exactly as intended. The focus reading matters: the button is only enabled for a focused rich-text input, so without `ANKI-EDITABLE` / `contenteditable: true` a disabled result would have been meaningless — that confound produced a false regression report once already.

## Accepted limitations

- A note bound for the **`Cloze (Hide all)`** note type gets flags derived from plain Cloze, because that target is only knowable once the note has content while the editor asks at load time.
- The editor no longer offers cloze in `Back`, but `contains_cloze`/`target_model` still scan every field, so pasting markup there still converts. Deliberate: making them consistent would block the add with Anki's "cloze outside cloze notetype" error, contradicting what this add-on is for. Nothing that works today stops working — the add-on just stops inviting the mistake.
- `col.models.cloze_fields()` on a note type id the collection no longer holds **panics** out of the Rust backend as a `BaseException`, which `except Exception` cannot catch. The code is safe because it resolves the note type with `get()` first and stops if it's gone; that ordering is load-bearing and is commented as such.

## Known gap

This does not fix the new Svelte editor (`NewEditor`, behind the `SVELTE_EDITOR` experiment flag, **off** by default). Its frontend fetches `getClozeFieldOrds` over HTTP, which `mediasrv.py:1177` routes straight to `col._backend.get_cloze_field_ords_raw`, bypassing Python entirely — so no Python-side approach, hook or patch, can reach it. That path is already broken for this add-on regardless: `maybe_show_cloze_button` would `AttributeError` on `editor.note` (`NewEditor` has only `nid`), and the note conversion relies on `add_cards_will_add_note`, which only the legacy `addcards_legacy.py` fires. Separate work, needed before Svelte becomes the default.
