### PR TITLE
Fix TypeError when adding a Basic note that uses the hide-all cloze syntax

### DIFF
--- a/src/basic2cloze/basic2cloze.py
+++ b/src/basic2cloze/basic2cloze.py
@@ -75,12 +75,12 @@ def main():
         ):
             return problem
 
-        if not target_model(note):
+        new_model = target_model(note)
+        if not new_model:
             tooltip("[Automatic Basic to Cloze] Cannot find 'Cloze' note type")
             return problem
 
         old_model = mw.col.models.get(note.mid)
-        new_model = target_model(note)
 
         field_values = [
             note[old_model["flds"][i]["name"]]

--- a/src/basic2cloze/model_selector.py
+++ b/src/basic2cloze/model_selector.py
@@ -6,8 +6,11 @@ from .model_finder import get_basic_note_type_ids, get_cloze_note_type
 
 CLOZE_HIDE_ALL_NAME = "Cloze (Hide all)"
 
-CLOZE_RE = r"\{\{c\d+::"
-HIDE_ALL_CLOZE_RE = r"\{\{c\d+::!"
+# named for the opening delimiter, not a whole cloze: basic2cloze.CLOZE_RE is a
+# different pattern that also requires the closing braces
+CLOZE_START_RE = r"\{\{c\d+::"
+# in the cloze-hide-all add-on a leading "!" marks a cloze that stays exposed
+EXPOSED_CLOZE_START_RE = CLOZE_START_RE + "!"
 
 
 def target_model(note):
@@ -15,14 +18,18 @@ def target_model(note):
     if note.note_type()["id"] not in get_basic_note_type_ids():
         return None
 
-    if not any(re.search(CLOZE_RE, value) for _, value in note.items()):
+    if not any(re.search(CLOZE_START_RE, value) for _, value in note.items()):
         return None
 
-    if any(re.search(HIDE_ALL_CLOZE_RE, value) for _, value in note.items()):
+    if any(re.search(EXPOSED_CLOZE_START_RE, value) for _, value in note.items()):
         hide_all_id = mw.col.models.id_for_name(CLOZE_HIDE_ALL_NAME)
         if hide_all_id:
             return mw.col.models.get(hide_all_id)
-        # that note type comes from another add-on and is usually absent, so
-        # fall through to the plain Cloze type rather than refusing the add
+        # Fall through to the plain Cloze type rather than refuse the add. That
+        # note type belongs to the cloze-hide-all add-on, which now calls it
+        # legacy and applies hide-all to regular Cloze notes instead -- so its
+        # absence often means the plain type is the correct target. Don't strip
+        # the "!" either: it is only a marker to that add-on, and is ordinary
+        # answer text in clozes like {{c1::!=}}.
 
     return get_cloze_note_type()

--- a/src/basic2cloze/model_selector.py
+++ b/src/basic2cloze/model_selector.py
@@ -4,13 +4,10 @@ from aqt import mw
 
 from .model_finder import get_basic_note_type_ids, get_cloze_note_type
 
-# Matched exactly, so the case matters: this is `model_name` in the Cloze (Hide
-# All) add-on, trgkanki/cloze_hide_all src/model/consts.py. Its README spells it
-# "Hide All" in prose, but the note type it registers is "Hide all".
+# Looked up by exact name, and trgkanki/cloze_hide_all registers it as "Hide
+# all" (src/model/consts.py) while spelling it "Hide All" in its README.
 CLOZE_HIDE_ALL_NAME = "Cloze (Hide all)"
 
-# named for the opening delimiter, not a whole cloze: basic2cloze.CLOZE_RE is a
-# different pattern that also requires the closing braces
 CLOZE_START_RE = r"\{\{c\d+::"
 # in the cloze-hide-all add-on a leading "!" marks a cloze that stays exposed
 EXPOSED_CLOZE_START_RE = CLOZE_START_RE + "!"
@@ -28,11 +25,9 @@ def target_model(note):
         hide_all_id = mw.col.models.id_for_name(CLOZE_HIDE_ALL_NAME)
         if hide_all_id:
             return mw.col.models.get(hide_all_id)
-        # Fall through to the plain Cloze type rather than refuse the add. The
-        # hide-all behaviour is lost -- that add-on now applies it via a marker
-        # on the note, which a note we just converted will not carry -- so the
-        # "!" ends up as literal answer text. Still better than blocking the
-        # add, and it must not be stripped: "!" is ordinary cloze content in
-        # answers like {{c1::!=}}, with no way to tell marker from text.
+        # Fall through to plain Cloze rather than refuse the add. Hide-all is
+        # lost (that add-on now marks notes, not note types), leaving "!" as
+        # literal text -- but it must not be stripped: "!" is ordinary content
+        # in answers like {{c1::!=}}.
 
     return get_cloze_note_type()

--- a/src/basic2cloze/model_selector.py
+++ b/src/basic2cloze/model_selector.py
@@ -1,23 +1,28 @@
 import re
 
+from aqt import mw
+
 from .model_finder import get_basic_note_type_ids, get_cloze_note_type
 
-clozeHideAllType = "Cloze (Hide all)"
+CLOZE_HIDE_ALL_NAME = "Cloze (Hide all)"
+
+CLOZE_RE = r"\{\{c\d+::"
+HIDE_ALL_CLOZE_RE = r"\{\{c\d+::!"
 
 
 def target_model(note):
-    if note.note_type()['id'] not in get_basic_note_type_ids():
+    """The note type this note should become, or None to leave it alone."""
+    if note.note_type()["id"] not in get_basic_note_type_ids():
         return None
 
-    # Cloze (Hide All) type
-    for _, val in note.items():
-        if re.search(r"\{\{c(\d+)::!", val):
-            return clozeHideAllType
+    if not any(re.search(CLOZE_RE, value) for _, value in note.items()):
+        return None
 
-    # Basic cloze type
-    for _, val in note.items():
-        if re.search(r"\{\{c(\d+)::", val):
-            return get_cloze_note_type()
+    if any(re.search(HIDE_ALL_CLOZE_RE, value) for _, value in note.items()):
+        hide_all_id = mw.col.models.id_for_name(CLOZE_HIDE_ALL_NAME)
+        if hide_all_id:
+            return mw.col.models.get(hide_all_id)
+        # that note type comes from another add-on and is usually absent, so
+        # fall through to the plain Cloze type rather than refusing the add
 
-    # None for no-change
-    return None
+    return get_cloze_note_type()

--- a/src/basic2cloze/model_selector.py
+++ b/src/basic2cloze/model_selector.py
@@ -4,6 +4,9 @@ from aqt import mw
 
 from .model_finder import get_basic_note_type_ids, get_cloze_note_type
 
+# Matched exactly, so the case matters: this is `model_name` in the Cloze (Hide
+# All) add-on, trgkanki/cloze_hide_all src/model/consts.py. Its README spells it
+# "Hide All" in prose, but the note type it registers is "Hide all".
 CLOZE_HIDE_ALL_NAME = "Cloze (Hide all)"
 
 # named for the opening delimiter, not a whole cloze: basic2cloze.CLOZE_RE is a
@@ -25,11 +28,11 @@ def target_model(note):
         hide_all_id = mw.col.models.id_for_name(CLOZE_HIDE_ALL_NAME)
         if hide_all_id:
             return mw.col.models.get(hide_all_id)
-        # Fall through to the plain Cloze type rather than refuse the add. That
-        # note type belongs to the cloze-hide-all add-on, which now calls it
-        # legacy and applies hide-all to regular Cloze notes instead -- so its
-        # absence often means the plain type is the correct target. Don't strip
-        # the "!" either: it is only a marker to that add-on, and is ordinary
-        # answer text in clozes like {{c1::!=}}.
+        # Fall through to the plain Cloze type rather than refuse the add. The
+        # hide-all behaviour is lost -- that add-on now applies it via a marker
+        # on the note, which a note we just converted will not carry -- so the
+        # "!" ends up as literal answer text. Still better than blocking the
+        # add, and it must not be stripped: "!" is ordinary cloze content in
+        # answers like {{c1::!=}}, with no way to tell marker from text.
 
     return get_cloze_note_type()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,89 @@ SRC = Path(__file__).resolve().parent.parent / "src"
 
 BASIC_ID = 1111
 CLOZE_ID = 2222
+HIDE_ALL_ID = 3333
+
+BASIC = {"id": BASIC_ID, "name": "Basic", "flds": [{"name": "Front"}, {"name": "Back"}]}
+CLOZE = {
+    "id": CLOZE_ID,
+    "name": "Cloze",
+    "flds": [{"name": "Text"}, {"name": "Back Extra"}],
+}
+CLOZE_HIDE_ALL = {
+    "id": HIDE_ALL_ID,
+    "name": "Cloze (Hide all)",
+    "flds": [{"name": "Text"}, {"name": "Back Extra"}],
+}
+
+
+class FakeModels:
+    """The handful of ModelManager methods the add-on reaches for."""
+
+    def __init__(self, notetypes, cloze_ords=(0,), deleted_ids=()):
+        self.notetypes = {notetype["id"]: notetype for notetype in notetypes}
+        self.cloze_ords = cloze_ords
+        # ids model_finder cached at profile load, before the note type went
+        self.deleted_ids = set(deleted_ids)
+
+    def get(self, notetype_id):
+        if notetype_id in self.deleted_ids:
+            return None
+        return self.notetypes.get(notetype_id)
+
+    def id_for_name(self, name):
+        for notetype in self.notetypes.values():
+            if notetype["name"] == name:
+                return notetype["id"]
+        return None
+
+    def cloze_fields(self, notetype_id):
+        if self.get(notetype_id) is None:
+            # the real backend panics on an unknown id, and a panic is a
+            # BaseException, so the add-on's except Exception won't save it
+            raise BaseException(f"panic: no note type {notetype_id}")
+        # only the Cloze note type has cloze fields, so asking about the
+        # wrong one has to come back empty rather than quietly succeed
+        return list(self.cloze_ords) if notetype_id == CLOZE_ID else []
+
+
+class EditableNote:
+    """Enough of anki.notes.Note for the conversion to be exercised.
+
+    The signature matters: convert_basic_to_cloze re-inits the note in place as
+    `note.__init__(col, new_model)`, which in Anki yields a blank note of that
+    note type -- hence the reset here.
+    """
+
+    def __init__(self, col, notetype, id=None):
+        self._notetype = notetype
+        self.fields = [""] * len(notetype["flds"])
+        self.tags = []
+
+    @property
+    def mid(self):
+        return self._notetype["id"]
+
+    def note_type(self):
+        return self._notetype
+
+    def keys(self):
+        return [field["name"] for field in self._notetype["flds"]]
+
+    def items(self):
+        return list(zip(self.keys(), self.fields))
+
+    def __getitem__(self, name):
+        return self.fields[self.keys().index(name)]
+
+    def __setitem__(self, name, value):
+        self.fields[self.keys().index(name)] = value
+
+
+def basic_note(*field_values):
+    note = EditableNote(None, BASIC)
+    for index, value in enumerate(field_values):
+        note.fields[index] = value
+    return note
 
 
 class FilterHook:
@@ -40,17 +123,18 @@ class FakeNote:
 
 @pytest.fixture
 def load_addon(monkeypatch):
-    """Import the add-on against stubbed Anki modules and return its gui_hooks.
+    """Import the add-on against stubbed Anki modules.
 
     `basic2cloze.__init__` calls main() on import, so importing is what
-    registers the hooks.
+    registers the hooks. Returns the stubbed gui_hooks, the fake ModelManager,
+    and the list any tooltip() text lands in.
     """
 
     def load(
         *,
         cloze_fields_exists: bool,
         hook_exists: bool = True,
-        has_cloze_note_type: bool = True,
+        notetypes=(BASIC, CLOZE),
         # stock Cloze: Text is a cloze field, Back Extra is not
         cloze_ords: tuple = (0,),
         # ids the cache still knows but the collection no longer has, i.e.
@@ -58,6 +142,7 @@ def load_addon(monkeypatch):
         deleted_note_type_ids: tuple = (),
     ):
         profile_hooks = []
+        tooltips = []
 
         anki = types.ModuleType("anki")
         anki.version = "26.8.1"
@@ -67,7 +152,7 @@ def load_addon(monkeypatch):
         anki_hooks.addHook = lambda name, cb: profile_hooks.append((name, cb))
 
         anki_notes = types.ModuleType("anki.notes")
-        anki_notes.Note = FakeNote
+        anki_notes.Note = EditableNote
         anki_notes.NoteFieldsCheckResult = types.SimpleNamespace(
             NORMAL=0, NOTETYPE_NOT_CLOZE=1, FIELD_NOT_CLOZE=2
         )
@@ -81,28 +166,7 @@ def load_addon(monkeypatch):
         anki_models = types.ModuleType("anki.models")
         anki_models.ModelManager = ModelManager
 
-        notetype_ids = {"Basic": BASIC_ID}
-        if has_cloze_note_type:
-            notetype_ids["Cloze"] = CLOZE_ID
-
-        existing_notetypes = set(notetype_ids.values()) - set(deleted_note_type_ids)
-
-        def cloze_fields(notetype_id):
-            if notetype_id not in existing_notetypes:
-                # the real backend panics on an unknown id, and a panic is a
-                # BaseException, so the add-on's except Exception won't save it
-                raise BaseException(f"panic: no note type {notetype_id}")
-            # only the Cloze note type has cloze fields, so asking about the
-            # wrong one has to come back empty rather than quietly succeed
-            return list(cloze_ords) if notetype_id == CLOZE_ID else []
-
-        models = types.SimpleNamespace(
-            id_for_name=notetype_ids.get,
-            get=lambda notetype_id: (
-                {"id": notetype_id} if notetype_id in existing_notetypes else None
-            ),
-            cloze_fields=cloze_fields,
-        )
+        models = FakeModels(notetypes, cloze_ords, deleted_note_type_ids)
         mw = types.SimpleNamespace(col=types.SimpleNamespace(models=models))
 
         gui_hooks = types.SimpleNamespace(
@@ -133,7 +197,7 @@ def load_addon(monkeypatch):
         aqt_editor.MODEL_CLOZE = 1
 
         aqt_utils = types.ModuleType("aqt.utils")
-        aqt_utils.tooltip = lambda *args, **kwargs: None
+        aqt_utils.tooltip = lambda text, *args, **kwargs: tooltips.append(text)
         aqt_utils.tr = types.SimpleNamespace(
             notetypes_basic_name=lambda: "Basic",
             notetypes_cloze_name=lambda: "Cloze",
@@ -172,6 +236,8 @@ def load_addon(monkeypatch):
             if name == "profileLoaded":
                 callback()  # populates model_finder's cached notetype ids
 
-        return gui_hooks
+        return types.SimpleNamespace(
+            gui_hooks=gui_hooks, models=models, tooltips=tooltips
+        )
 
     return load

--- a/tests/test_cloze_field_hook.py
+++ b/tests/test_cloze_field_hook.py
@@ -4,7 +4,7 @@ import pytest
 
 from conftest import BASIC, BASIC_ID, CLOZE_ID, FakeNote
 
-UNRELATED_ID = 3333
+UNRELATED_ID = 9999  # distinct from every id conftest hands out
 
 
 @pytest.fixture

--- a/tests/test_cloze_field_hook.py
+++ b/tests/test_cloze_field_hook.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from conftest import BASIC_ID, CLOZE_ID, FakeNote
+from conftest import BASIC, BASIC_ID, CLOZE_ID, FakeNote
 
 UNRELATED_ID = 3333
 
@@ -10,7 +10,8 @@ UNRELATED_ID = 3333
 @pytest.fixture
 def flag_cloze_fields(load_addon):
     def make(**kwargs):
-        hook = load_addon(cloze_fields_exists=True, **kwargs).editor_will_load_note
+        addon = load_addon(cloze_fields_exists=True, **kwargs)
+        hook = addon.gui_hooks.editor_will_load_note
         assert len(hook.callbacks) == 1
         return hook.callbacks[0]
 
@@ -45,7 +46,7 @@ def test_flags_follow_a_customised_cloze_note_type(flag_cloze_fields):
 def test_nothing_is_flagged_without_a_cloze_note_type(flag_cloze_fields):
     """Conversion would refuse and Anki would block the add, so an enabled
     cloze button could only lead to a note that cannot be added."""
-    hook = flag_cloze_fields(has_cloze_note_type=False)
+    hook = flag_cloze_fields(notetypes=(BASIC,))
 
     assert hook("js;", FakeNote(BASIC_ID, 2), None) == "js;"
 
@@ -86,14 +87,14 @@ def test_a_raising_note_does_not_take_the_hook_down_with_it(widen_cloze_fields):
 
 def test_hook_is_not_registered_on_anki_without_cloze_fields(load_addon):
     """Before Anki 25.9 there were no per-field cloze flags to widen."""
-    gui_hooks = load_addon(cloze_fields_exists=False)
+    gui_hooks = load_addon(cloze_fields_exists=False).gui_hooks
 
     assert gui_hooks.editor_will_load_note.callbacks == []
 
 
 def test_addon_still_loads_if_anki_drops_the_hook(load_addon):
     """Registering blind would AttributeError and take the add-on with it."""
-    gui_hooks = load_addon(cloze_fields_exists=True, hook_exists=False)
+    gui_hooks = load_addon(cloze_fields_exists=True, hook_exists=False).gui_hooks
 
     assert not hasattr(gui_hooks, "editor_will_load_note")
     # the rest of the add-on still came up

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -44,6 +44,7 @@ def test_tags_survive_the_conversion(convert):
 
     convert_basic_to_cloze(None, note)
 
+    assert note.note_type()["id"] == CLOZE_ID, "otherwise nothing was converted"
     assert note.tags == ["geography", "marked"]
 
 
@@ -90,6 +91,9 @@ def test_hide_all_syntax_falls_back_when_that_note_type_is_missing(convert):
 def test_no_cloze_note_type_at_all_blocks_the_add_with_a_tooltip(convert):
     convert_basic_to_cloze, addon = convert(notetypes=(BASIC,))
     note = basic_note("{{c1::orphaned}}")
+    # model_finder warns about the missing note type at profile load too, so
+    # only tooltips from the conversion itself should count here
+    addon.tooltips.clear()
 
     problem = convert_basic_to_cloze(NOT_CLOZE_PROBLEM, note)
 
@@ -98,8 +102,39 @@ def test_no_cloze_note_type_at_all_blocks_the_add_with_a_tooltip(convert):
     assert any("Cloze" in text for text in addon.tooltips)
 
 
-def test_field_values_are_not_lost_when_the_target_has_fewer_fields(convert):
-    """Basic and Cloze both have two fields today; don't rely on that."""
+def test_hide_all_is_reachable_without_a_plain_cloze_note_type(convert):
+    """The hide-all branch returns before the plain Cloze lookup, so a
+    collection with only that note type still converts."""
+    convert_basic_to_cloze, _ = convert(notetypes=(BASIC, CLOZE_HIDE_ALL))
+    note = basic_note("{{c1::!hidden}}")
+
+    problem = convert_basic_to_cloze(NOT_CLOZE_PROBLEM, note)
+
+    assert problem is None
+    assert note.note_type()["id"] == HIDE_ALL_ID
+
+
+def test_surplus_target_fields_are_left_blank(convert):
+    three_field_cloze = {
+        "id": CLOZE_ID,
+        "name": "Cloze",
+        "flds": [{"name": "Text"}, {"name": "Back Extra"}, {"name": "Notes"}],
+    }
+    convert_basic_to_cloze, _ = convert(notetypes=(BASIC, three_field_cloze))
+    note = basic_note("{{c1::kept}}", "extra")
+
+    problem = convert_basic_to_cloze(NOT_CLOZE_PROBLEM, note)
+
+    assert problem is None
+    assert note.fields == ["{{c1::kept}}", "extra", ""]
+
+
+def test_overlapping_fields_are_kept_when_the_target_has_fewer_fields(convert):
+    """The surplus field is silently dropped -- pre-existing, documented here.
+
+    Basic and Cloze both have two fields today, so nothing hits this in a
+    stock collection, but neither note type is guaranteed to stay that way.
+    """
     one_field_cloze = {"id": CLOZE_ID, "name": "Cloze", "flds": [{"name": "Text"}]}
     convert_basic_to_cloze, _ = convert(notetypes=(BASIC, one_field_cloze))
     note = basic_note("{{c1::kept}}", "dropped")
@@ -107,4 +142,4 @@ def test_field_values_are_not_lost_when_the_target_has_fewer_fields(convert):
     problem = convert_basic_to_cloze(NOT_CLOZE_PROBLEM, note)
 
     assert problem is None
-    assert note["Text"] == "{{c1::kept}}"
+    assert note.fields == ["{{c1::kept}}"], "'dropped' has nowhere to go"

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,0 +1,110 @@
+"""Covers the conversion itself: a Basic note with clozes becoming a Cloze note.
+
+This is what the add-on is for, and it runs as an `add_cards_will_add_note`
+filter: returning None clears Anki's objection to clozes in a non-cloze note
+type and lets the add proceed, while returning the problem blocks it.
+"""
+
+import pytest
+
+from conftest import BASIC, CLOZE, CLOZE_HIDE_ALL, CLOZE_ID, HIDE_ALL_ID, basic_note
+
+NOT_CLOZE_PROBLEM = "you have a cloze deletion outside a cloze note type"
+
+
+@pytest.fixture
+def convert(load_addon):
+    """The registered filter, plus the fake collection it runs against."""
+
+    def make(notetypes=(BASIC, CLOZE)):
+        addon = load_addon(cloze_fields_exists=True, notetypes=notetypes)
+        hook = addon.gui_hooks.add_cards_will_add_note
+        assert len(hook.callbacks) == 1
+        return hook.callbacks[0], addon
+
+    return make
+
+
+def test_basic_note_with_a_cloze_becomes_a_cloze_note(convert):
+    convert_basic_to_cloze, _ = convert()
+    note = basic_note("Canberra is the capital of {{c1::Australia}}", "extra")
+
+    problem = convert_basic_to_cloze(NOT_CLOZE_PROBLEM, note)
+
+    assert problem is None, "Anki's objection should have been cleared"
+    assert note.note_type()["id"] == CLOZE_ID
+    assert note["Text"] == "Canberra is the capital of {{c1::Australia}}"
+    assert note["Back Extra"] == "extra"
+
+
+def test_tags_survive_the_conversion(convert):
+    convert_basic_to_cloze, _ = convert()
+    note = basic_note("{{c1::tagged}}")
+    note.tags = ["geography", "marked"]
+
+    convert_basic_to_cloze(None, note)
+
+    assert note.tags == ["geography", "marked"]
+
+
+def test_basic_note_without_a_cloze_is_left_alone(convert):
+    convert_basic_to_cloze, _ = convert()
+    note = basic_note("plain front", "plain back")
+
+    problem = convert_basic_to_cloze(NOT_CLOZE_PROBLEM, note)
+
+    assert problem == NOT_CLOZE_PROBLEM, "nothing to convert, so don't interfere"
+    assert note.note_type()["id"] == BASIC["id"]
+
+
+def test_hide_all_syntax_uses_the_hide_all_note_type(convert):
+    """`{{c1::!...}}` is the marker for the "Cloze (Hide all)" note type."""
+    convert_basic_to_cloze, _ = convert(notetypes=(BASIC, CLOZE, CLOZE_HIDE_ALL))
+    note = basic_note("{{c1::!hidden}}", "extra")
+
+    problem = convert_basic_to_cloze(NOT_CLOZE_PROBLEM, note)
+
+    assert problem is None
+    assert note.note_type()["id"] == HIDE_ALL_ID
+    assert note["Text"] == "{{c1::!hidden}}"
+    assert note["Back Extra"] == "extra"
+
+
+def test_hide_all_syntax_falls_back_when_that_note_type_is_missing(convert):
+    """Most collections have no "Cloze (Hide all)"; adding must still work.
+
+    This is the regression that used to raise TypeError out of the filter hook,
+    which Anki responds to by unregistering the callback -- so the first note
+    with this syntax also killed conversion for the rest of the session.
+    """
+    convert_basic_to_cloze, _ = convert(notetypes=(BASIC, CLOZE))
+    note = basic_note("{{c1::!hidden}}", "extra")
+
+    problem = convert_basic_to_cloze(NOT_CLOZE_PROBLEM, note)
+
+    assert problem is None
+    assert note.note_type()["id"] == CLOZE_ID
+    assert note["Text"] == "{{c1::!hidden}}"
+
+
+def test_no_cloze_note_type_at_all_blocks_the_add_with_a_tooltip(convert):
+    convert_basic_to_cloze, addon = convert(notetypes=(BASIC,))
+    note = basic_note("{{c1::orphaned}}")
+
+    problem = convert_basic_to_cloze(NOT_CLOZE_PROBLEM, note)
+
+    assert problem == NOT_CLOZE_PROBLEM, "no target note type, so don't clear it"
+    assert note.note_type()["id"] == BASIC["id"]
+    assert any("Cloze" in text for text in addon.tooltips)
+
+
+def test_field_values_are_not_lost_when_the_target_has_fewer_fields(convert):
+    """Basic and Cloze both have two fields today; don't rely on that."""
+    one_field_cloze = {"id": CLOZE_ID, "name": "Cloze", "flds": [{"name": "Text"}]}
+    convert_basic_to_cloze, _ = convert(notetypes=(BASIC, one_field_cloze))
+    note = basic_note("{{c1::kept}}", "dropped")
+
+    problem = convert_basic_to_cloze(NOT_CLOZE_PROBLEM, note)
+
+    assert problem is None
+    assert note["Text"] == "{{c1::kept}}"


### PR DESCRIPTION
Rebased onto `master` after #11 was squash-merged, so this is now just the four commits below.

## The bug

Add a Basic note containing the hide-all cloze syntax, `{{c1::!something}}`, and the add fails with:

```
TypeError: string indices must be integers, not 'str'
```

`target_model()` returned the *string* `"Cloze (Hide all)"` for those notes, while `convert_basic_to_cloze()` treats the return value as a note type dict — so `len(new_model["flds"])` blew up.

It surfaces worse than a one-off error. The conversion runs as an `add_cards_will_add_note` filter, and Anki **unregisters a filter callback that raises**. So the first note using this syntax both failed to add *and* silently disabled Basic→Cloze conversion for the rest of the session.

Both paths were broken, not just the missing-note-type one: even with `Cloze (Hide all)` installed, the string was returned and the crash happened anyway.

## Provenance

It dates to the 2020 commit that added hide-all support (f577873), where *both* branches returned note type **names** and the caller resolved them through `modelExists`/`changeModelTo`. Later refactors moved the plain-cloze branch and the caller to note type dicts and dropped the existence check, but left this branch returning the name.

## The fix

`target_model()` now returns a note type dict on every path — the hide-all name is resolved through `id_for_name`/`get`, and the plain path goes through `get_cloze_note_type()`, the accessor #11 introduced so the conversion and the editor's cloze-field flags can't drift apart.

When `Cloze (Hide all)` is absent it falls back to the plain `Cloze` type rather than refusing the add. Also stopped calling `target_model()` twice per conversion.

## Why the `!` is left alone

The open question was what to do when that note type is missing: fall back silently (what this does), refuse the add, or convert and strip the `!`.

**Stripping is the one clearly wrong option.** `{{c1::!=}}`, `{{c1::!important}}`, `{{c1::!true}}` are all plausible clozes, and nothing distinguishes a marker from content — stripping would silently corrupt them.

Falling back does lose the hide-all behaviour: that add-on now applies hide-all through a marker on the *note* rather than the note type, and a note we have just converted carries no such marker, so the `!` ends up as literal answer text. That is still better than blocking the add, which is what refusing would do.

The name is matched exactly, and it is worth knowing that `trgkanki/cloze_hide_all` registers the note type as `"Cloze (Hide all)"` (`src/model/consts.py`) while its README spells it "Cloze (Hide All)" — anyone comparing the two would reasonably think ours was the typo. That is now a comment.

## Tests

`convert_basic_to_cloze` is what this add-on is *for*, and it had no coverage at all, which is why this survived since 2020. Nine tests now cover it:

- **the two hide-all cases fail with the original `TypeError` before this change** — verified by running them against the unfixed source
- hide-all syntax uses `Cloze (Hide all)` when present, falls back to `Cloze` when not, and is reachable when only that note type exists
- a Basic note with a cloze becomes a Cloze note, with field values and tags carried across
- a Basic note *without* a cloze is left alone, and the problem is passed through rather than cleared
- the tooltip path when the collection has no cloze note type at all
- field behaviour when the target note type has fewer or more fields than Basic

The fakes gained an `EditableNote` mirroring `anki.notes.Note` closely enough for the in-place `note.__init__(col, new_model)` re-init the conversion relies on — including that a real `Note.__init__` blanks fields *and* tags, which is what makes the tag test non-vacuous.

Full suite: **29 passing**. The conversion tests are mutation-verified: deleting the conversion-time tooltip, the tag restore, the hide-all lookup, the hide-all early return, or the field copy each fails the corresponding test.

## Verified in a running Anki 26.08.1

Against a real profile, driven through a throwaway add-on:

```json
"start":                  { "filter_found": true, "get_cloze_note_type": "Cloze" },
"plain_cloze":            { "cleared": true, "notetype": "Cloze" },
"hide_all_with_notetype": { "cleared": true, "notetype": "Cloze (Hide all)" },
"no_cloze":               { "passed_through": true, "notetype": "Basic" }
```

An earlier run on a fresh profile also confirmed the missing-note-type case: `{{c1::!hidden}}` converts to `Cloze` with no exception — the path that used to throw.

## Note on the first commit message

The first commit says a missing note type "was the more likely way to hit the crash". That wording implies the crash depended on the note type being absent; it did not — the string was returned whenever the syntax matched, so it crashed either way. The intended point was that most affected users lack the note type, which is why the fallback covers the common case.
