### PR TITLE
Say we have tested Anki 26.08.1, not 2.1.54

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -9,5 +9,5 @@
         "anki21"
     ],
     "min_anki_version": "2.1.28",
-    "max_tested_anki_version": "2.1.54"
+    "max_tested_anki_version": "26.08.1"
 }


### PR DESCRIPTION
`max_tested_anki_version` still claimed **2.1.54** — about four years and a whole version scheme out of date — right after the add-on was fixed and verified end to end against **26.08.1**.

## This is documentation only

Worth stating plainly, because it is not obvious: **the installed aab ignores this field.**

The toolchain here is **aab v0.1.4** (in the `anki_*` virtualenvs). Its `Config.manifest()` emits `name`, `package`, `ankiweb_id`, `author`, `version`, `homepage`, `conflicts` and `mod`, and nothing else — no `min_point_version`, no `max_point_version`. So neither `min_anki_version` nor `max_tested_anki_version` reaches the built manifest today. (The `min_point_version: 28` in `build/dist/.../manifest.json` predates this and did not come from v0.1.4.)

## If aab is ever upgraded

Upstream is at `v1.0.0-dev.5` on branch `main`, last pushed 2024-03-20, and not on PyPI — so it would be a git install. It *does* emit the point versions, but two things would still bite:

1. **It reads a different key.** `tested_anki_version`, not `max_tested_anki_version`:
   ```python
   tested_anki_version = addon_properties.get("tested_anki_version")
   ```
   Our key would be silently ignored, and no `max_point_version` emitted.

2. **Its parser predates the current version scheme.**
   ```python
   def _anki_version_to_point_version(cls, version: str) -> int:
       return int(version.split(".")[-1])
   ```
   `"2.1.54"` → `54`, correct. `"26.08.1"` → **1**, where `anki.utils.point_version()` actually reports `260801`.

Neither is dangerous. Anki only refuses an add-on when `max_point_version` is **negative**:

```python
# aqt/addons.py
if max is not None and max < 0 and _current_version > abs(max):
    return False
```

Negatives come from the separate `max_anki_version` key; `tested_anki_version` is written positive and is never consulted by `compatible()`. The only other reader, `compatible_string()`, renders solely for add-ons already deemed incompatible.

`min_anki_version` is deliberately untouched — the version-gated branches back to 2.1.28 weren't changed or tested here.
